### PR TITLE
Reimplementation of the `signal_to_noise_ratio()` function.

### DIFF
--- a/tests/test_ranker.py
+++ b/tests/test_ranker.py
@@ -128,7 +128,7 @@ def test_signal_to_noise_ratio(test_case_data, test_control_data):
 
     expected = pd.DataFrame({
         "gene_id": ["gene_1", "gene_2", "gene_3"],
-        "ranking": [-0.6253909, -1.0638298, 0.6423481]
+        "ranking": [-1.0982062, -0.4333077, 3.6338295]
     })
 
     computed = signal_to_noise_ratio(dual_data)


### PR DESCRIPTION
S2N should be compliant with the standard definition of _signal_to_noise_ratio_ (see e.g., PMID: 28499413), namely
```math
\textrm{S2N}=\frac{\bar{x}_{1}-\bar{x}_{2}}{s_1+s_2}
```
In particular, notice that:
- _s_ is the **standard deviation** and not the **variance**
- the noise (again the standard deviation _s_) is to be computed _within_ the two groups (_case_ and _control_) separately