### PR TITLE
Bessel's corretion of the variance

### DIFF
--- a/gene_ranker/ranking_methods.py
+++ b/gene_ranker/ranking_methods.py
@@ -181,9 +181,9 @@ def signal_to_noise_ratio(dual_dataset: DualDataset) -> pd.DataFrame:
     control = dual_dataset.control.set_index(dual_dataset.on)
 
     case_means = case.apply(mean, axis=1)
-    case_stdev = case.apply(std, axis=1)
+    case_stdev = case.apply(lambda x: std(x, ddof=1), axis=1)
     control_means = control.apply(mean, axis=1)
-    control_stdev = control.apply(std, axis=1)
+    control_stdev = control.apply(lambda x: std(x, ddof=1), axis=1)
 
     # Assume that the values are logged
     signal = case_means.to_numpy() - control_means.to_numpy()


### PR DESCRIPTION
I still had a minor discrepancy between expected and experimental results when using the S2N metric, so I found that NumPy's `var` and `std` functions do not correct for bias by default (see documentation [here](https://numpy.org/doc/stable/reference/generated/numpy.std.html)).

To set the parameter `ddof=1` instead of `ddof=0`, I introduced lambda functions in `signal_to_noise_ratio` function to Bessel's correct the computation of standard deviation, in order to have a less biased and more standards-compliant estimator.