### PR TITLE
Comments and thoughts on BWS statistic in 'ranking_methods.py'

### DIFF
--- a/gene_ranker/ranking_methods.py
+++ b/gene_ranker/ranking_methods.py
@@ -200,7 +200,6 @@ def signal_to_noise_ratio(dual_dataset: DualDataset) -> pd.DataFrame:
 def bws_rank(dual_dataset: DualDataset) -> pd.DataFrame:
     dual_dataset.sync()
     
-    # The statistic is identical if we swap case and controls
     case = dual_dataset.case.loc[:, dual_dataset.case.columns != dual_dataset.on]
     control = dual_dataset.control.loc[:, dual_dataset.control.columns != dual_dataset.on]
     stats = []
@@ -209,8 +208,7 @@ def bws_rank(dual_dataset: DualDataset) -> pd.DataFrame:
     for (_, case), (_, control) in zip(case.iterrows(), control.iterrows()):
         # I needed to get the private method for the statistic that is then
         # resampled many times for the test. The signature therefore is a bit
-        # cryptic. The last 0 is the axis but it has no effect on the call.
-        # (as far as I can see) and in any case is what bws_test uses
+        # cryptic. The last 0 is the axis.
         stats.append(_bws_statistic(case, control, 'one-sided', 0))
 
     return pd.DataFrame({


### PR DESCRIPTION
The **two-sided** _B_ statistic (as stated by the authors of the paper [1] and also in the _BMC Bioinformatics_ paper [2]) is usually a _positively defined_ metric, which therefore captures only the **_absolute value_** of a squared (weighted) difference between two cumulative distribution functions (just like the Kolmogorov-Smirnov distance does, but weighted with variance, thus emphasizing tails). In that, I think it has little to do with the other metrics we present... and I would lean toward dropping it completely.

However, using the **one-sided** version might make sense, ...but the approach is still questionable: first it is **not** the one reported in [2] (for which one can claim certain particular properties of stability and robustness against errors of various kinds), and, second, even that paper does **not** say that that metric is usually implemented in GSEA, but only that it “_has been used before_”. But if you then go and look at the reference in bibliography it is just one conference paper from a 2007 Brazilian Symposium on Bioinformatics society... (Bayá AE, Larese MG, Granitto PM, Gómez JC, Tapia E. Gene set enrichment analysis using non-parametric scores. In: Brazilian Symposium on Bioinformatics. Berlin Heidelberg: Springer: 2007. p. 12–21). ...not that I have anything against Brazilian people, but you can't even find that document in PubMed or anywhere else... come on!

In summary, I locally tested that:
```
# The statistic is identical if we swap case and controls.
```
is true only when `alternative == 'two-sided`, otherwise the B statistic will have a sign. The good news is that the way the function is written now leads to the "correct" sign (treatment vs control).

In addition, it is not true that the `axis` parameter does not count: if it is not 0, i.e. the computation is not column-wise, the script breaks.
So I also removed this part of the comment:
```
# The last 0 is the axis but it has no effect on the call.
# (as far as I can see) and in any case is what bws_test uses
```

Finally, there is no way to have a match between R and python regarding the BWS statistic, but I trust python more, whose code [is clearly visible](https://github.com/scipy/scipy/blob/v1.14.1/scipy/stats/_bws_test.py#L32-L59), [well documented](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.bws_test.html#scipy.stats.bws_test), and correct with respect to the original authors' definition.


```python
from scipy.stats._bws_test import _bws_statistic
import numpy as np

x = np.array([1,2,3,2,1,1])
y = np.array([-1,-3,-4,-5,-7,-2,-1])

_bws_statistic(x, y, 'two-sided', 0)
_bws_statistic(y, x, 'two-sided', 0)
_bws_statistic(y, x, 'two-sided', 1)

_bws_statistic(x, y, 'one-sided', 0)
_bws_statistic(y, x, 'one-sided', 0)
_bws_statistic(y, x, 'one-sided', 1)
```
compare with:
```r
library(BWStest)

x <- c(1,2,3,2,1,1)
y <- c(-1,-3,-4,-5,-7,-2,-1)

bws_stat(x,y)
bws_stat(y,x)
```
[1] [BF02762032.pdf](https://github.com/user-attachments/files/17756423/BF02762032.pdf)
[2] [s12859-017-1674-0.pdf](https://github.com/user-attachments/files/17756420/s12859-017-1674-0.pdf)
